### PR TITLE
Bulb service rounding

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -36,6 +36,12 @@
                 "description": "The Homekit Accessory Protocol has deprecated `public.hap.service.fan`",
                 "type": "boolean"
             },
+            "roundUp":{
+                "title": "Round up lighting values to 100%",
+                "default": true,
+                "description": "Z-Wave devices actually only have a range of 1-99, while 0 is off. You can round this in homebridge, since Homekit has a range of 0-100",
+                "type": "boolean"
+            },
 			"temperatureUnits": {
 				"title": "Temperature Display Units",
 				"type": "string",

--- a/config.schema.json
+++ b/config.schema.json
@@ -30,6 +30,12 @@
                 "title": "Low Battery Threshold",
                 "type": "integer"
             },
+            "fanv2": {
+                "title": "Use Fanv2 service (default)",
+                "default": true,
+                "description": "The Homekit Accessory Protocol has deprecated `public.hap.service.fan`",
+                "type": "boolean"
+            },
 			"temperatureUnits": {
 				"title": "Temperature Display Units",
 				"type": "string",

--- a/config.schema.json
+++ b/config.schema.json
@@ -30,12 +30,6 @@
                 "title": "Low Battery Threshold",
                 "type": "integer"
             },
-            "fanv2": {
-                "title": "Use Fanv2 service (default)",
-                "default": true,
-                "description": "The Homekit Accessory Protocol has deprecated `public.hap.service.fan`",
-                "type": "boolean"
-            },
             "roundUp":{
                 "title": "Round up lighting values to 100%",
                 "default": true,

--- a/lib/Setup LightsFansPlugs.js
+++ b/lib/Setup LightsFansPlugs.js
@@ -51,7 +51,7 @@ exports.setupLightsFansPlugs = function (that, services)
 
 	let round = function (level)
 	{
-		that.log(chalk.cyan(`Rounding based on roundUp config (${roundUp}): ${level}.`));
+		//that.log(chalk.cyan(`Rounding based on roundUp config (${roundUp}): ${level}.`));
 		return roundUp && level >= 99 ? 100 : level;
 	}
 

--- a/lib/Setup LightsFansPlugs.js
+++ b/lib/Setup LightsFansPlugs.js
@@ -48,10 +48,11 @@ exports.setupLightsFansPlugs = function (that, services)
 	let Characteristic 	= that.api.hap.Characteristic;
 	let Service 		= that.api.hap.Service;
 	let roundUp 		= that.platformConfig.roundUp;
+
 	let round = function (level)
 	{
-		that.log(that.platformConfig.roundUp);
 		that.log(chalk.cyan(`Rounding based on roundUp config (${roundUp}): ${level}.`));
+		return roundUp && level >= 99 ? 100 : level;
 	}
 
 	if (that.currentAccessory.capabilities.includes("Switch"))
@@ -198,8 +199,8 @@ exports.setupLightsFansPlugs = function (that, services)
 					.setInitialValue(that.currentAccessory.attributes.level)
 					.on('HubValueChanged', function(HubReport, HomeKitObject)
 						{
-							round(HubReport.value);
-							LevelControl.updateValue(HubReport.value); 
+							let level = round(HubReport.value);
+							LevelControl.updateValue(level);
 						})
 					.on('set', function(newHomekitValue, callback, context)
 						{

--- a/lib/Setup LightsFansPlugs.js
+++ b/lib/Setup LightsFansPlugs.js
@@ -47,9 +47,10 @@ exports.setupLightsFansPlugs = function (that, services)
 {
 	let Characteristic 	= that.api.hap.Characteristic;
 	let Service 		= that.api.hap.Service;
-	let roundUp = that.platformConfig.roundUp;
+	let roundUp 		= that.platformConfig.roundUp;
 	let round = function (level)
 	{
+		that.log(that.platformConfig.roundUp);
 		that.log(chalk.cyan(`Rounding based on roundUp config (${roundUp}): ${level}.`));
 	}
 

--- a/lib/Setup LightsFansPlugs.js
+++ b/lib/Setup LightsFansPlugs.js
@@ -47,6 +47,11 @@ exports.setupLightsFansPlugs = function (that, services)
 {
 	let Characteristic 	= that.api.hap.Characteristic;
 	let Service 		= that.api.hap.Service;
+	let roundUp = that.platformConfig.roundUp;
+	let round = function (level)
+	{
+		that.log(chalk.cyan(`Rounding based on roundUp config (${roundUp}): ${level}.`));
+	}
 
 	if (that.currentAccessory.capabilities.includes("Switch"))
 	{
@@ -192,6 +197,7 @@ exports.setupLightsFansPlugs = function (that, services)
 					.setInitialValue(that.currentAccessory.attributes.level)
 					.on('HubValueChanged', function(HubReport, HomeKitObject)
 						{
+							round(HubReport.value);
 							LevelControl.updateValue(HubReport.value); 
 						})
 					.on('set', function(newHomekitValue, callback, context)
@@ -244,4 +250,5 @@ exports.setupLightsFansPlugs = function (that, services)
 			}
 		}
 	}
+	
 }


### PR DESCRIPTION
New option in config that allows bulb service to adhere to HomeKit paradigms with a range of  1-100% load level. Z-Wave devices only support levels 1-99, so this option will help those of us with largely z-wave homes. Open for feedback.