### PR TITLE
ThresholdTemperature in auto only and mode/temperature race fix

### DIFF
--- a/lib/Setup Thermostats.js
+++ b/lib/Setup Thermostats.js
@@ -63,7 +63,6 @@ exports.setupThermostat = function (that, services)
 			.setInitialValue(TargetStateReportMap.get(that.currentAccessory.attributes.thermostatMode))
 			.on('set', function(newHomekitValue, callback, context)
 			{
-				// console.log(chalk.yellow(`Sending TargetState value: ${newHomekitValue}`))
 				that.HubData.send(that.currentAccessory.id, TargetStateOnSetMap.get(newHomekitValue));
 				callback(null);
 			})
@@ -105,7 +104,8 @@ exports.setupThermostat = function (that, services)
 				{
 					var updateTemp = (that.platformConfig.temperatureUnits.includes("F"))
 							? Math.round((newHomekitValue * 1.8) + 32)
-							: newHomekitValue					
+							: newHomekitValue
+					
 						if (TargetState.value == 2) // 2 = homekit cool
 							{
 								that.HubData.send(that.currentAccessory.id, "setCoolingSetpoint", updateTemp );

--- a/lib/Setup Thermostats.js
+++ b/lib/Setup Thermostats.js
@@ -69,7 +69,7 @@ exports.setupThermostat = function (that, services)
 			})
 			.on('HubValueChanged', function(HubReport, HomeKitObject)
 			{ 
-				that.log(chalk.yellow(`Received TargetState value;`))
+				// console.log(chalk.yellow(`Received TargetState value;`))
 				TargetState.updateValue(TargetStateReportMap.get(HubReport.value));
 			});	
 		

--- a/lib/Setup Thermostats.js
+++ b/lib/Setup Thermostats.js
@@ -63,7 +63,7 @@ exports.setupThermostat = function (that, services)
 			.setInitialValue(TargetStateReportMap.get(that.currentAccessory.attributes.thermostatMode))
 			.on('set', function(newHomekitValue, callback, context)
 			{
-				that.log(chalk.yellow(`Sending TargetState value: ${newHomekitValue}`))
+				// console.log(chalk.yellow(`Sending TargetState value: ${newHomekitValue}`))
 				that.HubData.send(that.currentAccessory.id, TargetStateOnSetMap.get(newHomekitValue));
 				callback(null);
 			})
@@ -106,16 +106,13 @@ exports.setupThermostat = function (that, services)
 					var updateTemp = (that.platformConfig.temperatureUnits.includes("F"))
 							? Math.round((newHomekitValue * 1.8) + 32)
 							: newHomekitValue					
-						that.log(chalk.yellow(`Sending setPoint value: ${newHomekitValue} (${updateTemp}) based on state ${TargetState.value}`))
 						if (TargetState.value == 2) // 2 = homekit cool
 							{
 								that.HubData.send(that.currentAccessory.id, "setCoolingSetpoint", updateTemp );
-								CoolingSetpoint.updateValue(updateTemp);
 							}
 						if (TargetState.value == 1) // 1 = homekit heat
 							{
 								that.HubData.send(that.currentAccessory.id, "setHeatingSetpoint", updateTemp );
-								HeatingSetpoint.updateValue(updateTemp);
 							}						
 
 						callback(null);
@@ -161,7 +158,6 @@ exports.setupThermostat = function (that, services)
 							? Math.round((newHomekitValue * 1.8) + 32)
 							: newHomekitValue	
 
-					that.log(`setting threshold temperature heat`);
 					that.HubData.send(that.currentAccessory.id, "setHeatingSetpoint", updateTemp );
 					callback(null);
 				})			
@@ -191,7 +187,6 @@ exports.setupThermostat = function (that, services)
 							? Math.round((newHomekitValue * 1.8) + 32)
 							: newHomekitValue	
 
-					that.log('setting threshold temperature cool');
 					that.HubData.send(that.currentAccessory.id, "setCoolingSetpoint", updateTemp );
 					callback(null);
 				})

--- a/lib/Setup Thermostats.js
+++ b/lib/Setup Thermostats.js
@@ -63,6 +63,7 @@ exports.setupThermostat = function (that, services)
 			.setInitialValue(TargetStateReportMap.get(that.currentAccessory.attributes.thermostatMode))
 			.on('set', function(newHomekitValue, callback, context)
 			{
+				this.targetState = newHomekitValue; // waiting for callback isn't returned before setTargetTemp in scenes
 				that.HubData.send(that.currentAccessory.id, TargetStateOnSetMap.get(newHomekitValue));
 				callback(null);
 			})
@@ -106,11 +107,11 @@ exports.setupThermostat = function (that, services)
 							? Math.round((newHomekitValue * 1.8) + 32)
 							: newHomekitValue
 					
-						if (TargetState.value == 2) // 2 = homekit cool
+						if (this.targetState == 2) // 2 = homekit cool
 							{
 								that.HubData.send(that.currentAccessory.id, "setCoolingSetpoint", updateTemp );
 							}
-						if (TargetState.value == 1) // 1 = homekit heat
+						if (this.targetState == 1) // 1 = homekit heat
 							{
 								that.HubData.send(that.currentAccessory.id, "setHeatingSetpoint", updateTemp );
 							}						

--- a/lib/Setup Thermostats.js
+++ b/lib/Setup Thermostats.js
@@ -63,7 +63,6 @@ exports.setupThermostat = function (that, services)
 			.setInitialValue(TargetStateReportMap.get(that.currentAccessory.attributes.thermostatMode))
 			.on('set', function(newHomekitValue, callback, context)
 			{
-				this.targetState = newHomekitValue; // waiting for callback isn't returned before setTargetTemp in scenes
 				that.HubData.send(that.currentAccessory.id, TargetStateOnSetMap.get(newHomekitValue));
 				callback(null);
 			})
@@ -106,16 +105,18 @@ exports.setupThermostat = function (that, services)
 					var updateTemp = (that.platformConfig.temperatureUnits.includes("F"))
 							? Math.round((newHomekitValue * 1.8) + 32)
 							: newHomekitValue
-					
-						if (this.targetState == 2) // 2 = homekit cool
-							{
-								that.HubData.send(that.currentAccessory.id, "setCoolingSetpoint", updateTemp );
-							}
-						if (this.targetState == 1) // 1 = homekit heat
-							{
-								that.HubData.send(that.currentAccessory.id, "setHeatingSetpoint", updateTemp );
-							}						
 
+						setTimeout( function()
+						{
+							if (TargetState.value == 2) // 2 = homekit cool
+								{
+									that.HubData.send(that.currentAccessory.id, "setCoolingSetpoint", updateTemp );
+								}
+							if (TargetState.value == 1) // 1 = homekit heat
+								{
+									that.HubData.send(that.currentAccessory.id, "setHeatingSetpoint", updateTemp );
+								}						
+						}, 50);
 						callback(null);
 				})
 			.on('HubValueChanged', function(HubReport, HomeKitObject)

--- a/lib/Setup Thermostats.js
+++ b/lib/Setup Thermostats.js
@@ -58,17 +58,18 @@ exports.setupThermostat = function (that, services)
 				CurrentState.updateValue(currentOperatingState);
 			});	
 
-		var TargetState 		= ThermostatService.getCharacteristic(Characteristic.TargetHeatingCoolingState)
+		var TargetState = ThermostatService.getCharacteristic(Characteristic.TargetHeatingCoolingState)
 			.updateOnHubEvents(that.currentAccessory.id, "thermostatMode")
 			.setInitialValue(TargetStateReportMap.get(that.currentAccessory.attributes.thermostatMode))
 			.on('set', function(newHomekitValue, callback, context)
 			{
+				that.log(chalk.yellow(`Sending TargetState value: ${newHomekitValue}`))
 				that.HubData.send(that.currentAccessory.id, TargetStateOnSetMap.get(newHomekitValue));
 				callback(null);
 			})
 			.on('HubValueChanged', function(HubReport, HomeKitObject)
 			{ 
-				// console.log(chalk.yellow(`Received TargetState value;`))
+				that.log(chalk.yellow(`Received TargetState value;`))
 				TargetState.updateValue(TargetStateReportMap.get(HubReport.value));
 			});	
 		
@@ -105,14 +106,16 @@ exports.setupThermostat = function (that, services)
 					var updateTemp = (that.platformConfig.temperatureUnits.includes("F"))
 							? Math.round((newHomekitValue * 1.8) + 32)
 							: newHomekitValue					
-					
+						that.log(chalk.yellow(`Sending setPoint value: ${newHomekitValue} (${updateTemp}) based on state ${TargetState.value}`))
 						if (TargetState.value == 2) // 2 = homekit cool
 							{
 								that.HubData.send(that.currentAccessory.id, "setCoolingSetpoint", updateTemp );
+								CoolingSetpoint.updateValue(updateTemp);
 							}
 						if (TargetState.value == 1) // 1 = homekit heat
 							{
 								that.HubData.send(that.currentAccessory.id, "setHeatingSetpoint", updateTemp );
+								HeatingSetpoint.updateValue(updateTemp);
 							}						
 
 						callback(null);
@@ -134,7 +137,7 @@ exports.setupThermostat = function (that, services)
 						}
 					if((HubReport.name == "heatingSetpoint") && (TargetState.value == 1))
 						{
-							TargetTemperature.updateValue(updateTemp);	
+							TargetTemperature.updateValue(updateTemp);
 							return;
 						}
 					if(HubReport.name == "thermostatSetpoint")
@@ -153,10 +156,12 @@ exports.setupThermostat = function (that, services)
 			.updateOnHubEvents(that.currentAccessory.id, "heatingSetpoint")	
 			.on('set', function(newHomekitValue, callback, context)
 				{
+					if(TargetState.value !== 3) return callback(null);
 					var updateTemp = (that.platformConfig.temperatureUnits.includes("F"))
 							? Math.round((newHomekitValue * 1.8) + 32)
 							: newHomekitValue	
 
+					that.log(`setting threshold temperature heat`);
 					that.HubData.send(that.currentAccessory.id, "setHeatingSetpoint", updateTemp );
 					callback(null);
 				})			
@@ -181,10 +186,12 @@ exports.setupThermostat = function (that, services)
 			.updateOnHubEvents(that.currentAccessory.id, "coolingSetpoint")
 			.on('set', function(newHomekitValue, callback, context)
 				{
+					if(TargetState.value !== 3) return callback(null);
 					var updateTemp = (that.platformConfig.temperatureUnits.includes("F"))
 							? Math.round((newHomekitValue * 1.8) + 32)
 							: newHomekitValue	
 
+					that.log('setting threshold temperature cool');
 					that.HubData.send(that.currentAccessory.id, "setCoolingSetpoint", updateTemp );
 					callback(null);
 				})


### PR DESCRIPTION
When used in scenes, if the mode and temperature are set (from Cool to Heat for instance and establishing a set point), Homekit will send supplementary calls to HeatingThresholdTemperature and CoolingThresholdTemperature that race the standard call for TargetTemperature. The sequence of the mode commands and temperature commands are also sent in an unpredictable order.

Due to timing issues, and required delays, this often means the heatingSetpoint is set by the threshold call, and the TargetTemperature is ignored.

When not in a scene, this process of changing mode and temperature happen as separate interactions and do not send this supplementary command.

By checking TargetState, we can simply bounce these supplemental requests.