### PR TITLE
Update to work with Homebridge v2 API

### DIFF
--- a/lib/Setup Battery.js
+++ b/lib/Setup Battery.js
@@ -11,7 +11,7 @@ exports.setupBattery = function (that, services)
 		&& ( that.currentAccessory.attributes.battery !== null))		
 	{
 		
-		var thisBatteryService = new Service.BatteryService();
+		var thisBatteryService = new Service.Battery();
 		
 		var BatteryLevel =  thisBatteryService.getCharacteristic(Characteristic.BatteryLevel)
 			.updateOnHubEvents(that.currentAccessory.id, "battery")

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "url": "https://github.com/jvmahon/homebridge-hubitat/issues"
   },
   "engines": {
-    "node": ">=16.0.0",
-    "homebridge": ">=1.4.1"
+    "node": "^22.12.0 || ^24.0.0",
+    "homebridge": "^1.6.0 || ^2.0.0"
   },
   "dependencies": {
     "ws": "=7.5.7",


### PR DESCRIPTION
Update for Sensor use

```
// This
var thisBatteryService = new Service.BatteryService();
// To This
var thisBatteryService = new Service.Battery();